### PR TITLE
DEV: Update the linting setup scripts

### DIFF
--- a/mass-pr.js
+++ b/mass-pr.js
@@ -218,7 +218,9 @@ async function makePR({
     const errorMessage = error.response?.data?.errors?.[0]?.message;
 
     if (errorMessage && /A pull request already exists/.test(errorMessage)) {
-      log(`✅ PR already exists for '${repository}'`);
+      log(
+        `✅ PR already exists for '${repository}': https://github.com/${repository}/pulls`
+      );
     } else {
       console.error(error);
       throw `❓ Failed to create PR for '${repository}'`;

--- a/mass-pr.js
+++ b/mass-pr.js
@@ -171,8 +171,9 @@ async function makePR({
 
   if (ask) {
     log(`'${repository}' done`);
-    log(`Review result in ./${WORKSPACE_DIR}/repo. Press`);
-    log(`q to exit, or any other key to continue`);
+    log(
+      `Review result in ./${WORKSPACE_DIR}/repo. Press q to exit, or any other key to continue`
+    );
     const key = await waitForKeypress();
 
     if (key === "q") {

--- a/mass-pr.js
+++ b/mass-pr.js
@@ -134,22 +134,23 @@ async function makePR({
       }
 
       log(
-        `s to skip this repo, r to retry the script, p to make a PR anyway, any other key to exit`
+        `s to skip this repo, p to make a PR anyway, q to exit, r (or any other key) to retry the script`
       );
+
       const key = await waitForKeypress();
 
       if (key === "s") {
         log(`Skipping ${repository}`);
         return;
-      } else if (key === "r") {
-        log(`Retrying ${repository}`);
-        continue;
       } else if (key === "p") {
         log(`Making a PR anyway`);
         break;
-      } else {
+      } else if (key === "q") {
         log(`Exiting...`);
         exit(1);
+      } else {
+        log(`Retrying ${repository}`);
+        continue;
       }
     }
   }

--- a/mass-pr.js
+++ b/mass-pr.js
@@ -205,7 +205,7 @@ async function makePR({
   runInRepo("git", "push", "--no-progress", "-f", "origin", branch);
 
   try {
-    await octokit.request("POST /repos/{owner}/{repo}/pulls", {
+    const response = await octokit.request("POST /repos/{owner}/{repo}/pulls", {
       owner,
       repo: repoNoOwner,
       title: message,
@@ -213,7 +213,7 @@ async function makePR({
       base: defaultBranch,
       body,
     });
-    log(`✅ PR created for '${repository}'`);
+    log(`✅ PR created for '${repository}': ${response.data.html_url}`);
   } catch (error) {
     const errorMessage = error.response?.data?.errors?.[0]?.message;
 

--- a/scripts/ensure-minimum-scaffolding.sh
+++ b/scripts/ensure-minimum-scaffolding.sh
@@ -10,9 +10,7 @@ if [ ! -d "discourse-plugin-skeleton" ]; then
 fi
 
 # Use the current js linting setup
-REPO_NAME=$(basename -s '.git' $(git -C repo remote get-url origin))
 echo '{
-  "name": "'$REPO_NAME'",
   "private": true,
   "devDependencies": {
     "@discourse/lint-configs": "^1.3.5",

--- a/scripts/ensure-minimum-scaffolding.sh
+++ b/scripts/ensure-minimum-scaffolding.sh
@@ -9,11 +9,18 @@ if [ ! -d "discourse-plugin-skeleton" ]; then
   git clone --quiet --depth 1 https://github.com/discourse/discourse-plugin-skeleton discourse-plugin-skeleton
 fi
 
+# Use the current js linting setup
 REPO_NAME=$(basename -s '.git' $(git -C repo remote get-url origin))
-
-if [ ! -f "repo/package.json" ]; then
-  echo "{ \"name\": \"$REPO_NAME\", \"private\": true }" > repo/package.json
-fi
+echo '{
+  "name": "'$REPO_NAME'",
+  "private": true,
+  "devDependencies": {
+    "@discourse/lint-configs": "^1.3.5",
+    "ember-template-lint": "^5.13.0",
+    "eslint": "^8.56.0",
+    "prettier": "^2.8.8"
+  }
+}' > repo/package.json
 
 # Copy these files from skeleton if they do not already exist
 if [ -f "repo/plugin.rb" ]; then

--- a/scripts/ensure-minimum-scaffolding.sh
+++ b/scripts/ensure-minimum-scaffolding.sh
@@ -13,7 +13,7 @@ fi
 echo '{
   "private": true,
   "devDependencies": {
-    "@discourse/lint-configs": "^1.3.5",
+    "@discourse/lint-configs": "^1.3.7",
     "ember-template-lint": "^5.13.0",
     "eslint": "^8.56.0",
     "prettier": "^2.8.8"

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -55,6 +55,13 @@ else # Theme
   yarn prettier --write '{javascripts,desktop,mobile,common,scss,test}/**/*.{scss,js,gjs,hbs}' --no-error-on-unmatched-pattern
 fi
 
+# Do an extra check after prettier
+if [ -f "plugin.rb" ]; then
+  yarn eslint --fix --no-error-on-unmatched-pattern {test,assets,admin/assets}/javascripts || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)
+else # Theme
+  yarn eslint --fix --no-error-on-unmatched-pattern {test,javascripts} || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)
+fi
+
 cd ..
 
 ../scripts/update-workflows.sh

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -36,7 +36,7 @@ if [ -f "plugin.rb" ]; then
 fi
 
 # Use the current linting setup
-yarn remove eslint-config-discourse || true
+yarn remove eslint-config-discourse --silent || true
 yarn add --dev @discourse/lint-configs@^1.3.1 eslint@^8.55.0 prettier@^2.8.8 ember-template-lint@^5.13.0
 
 if [ -f "plugin.rb" ]; then

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -33,7 +33,7 @@ fi
 
 # Use the current linting setup
 yarn remove eslint-config-discourse || true
-yarn add --dev @discourse/lint-configs eslint prettier@^2.8.8 ember-template-lint
+yarn add --dev @discourse/lint-configs eslint@^8.51.0 prettier@^2.8.8 ember-template-lint
 
 if [ -f "plugin.rb" ]; then
   yarn prettier --write '{assets,test}/**/*.{scss,js,gjs,hbs}' --no-error-on-unmatched-pattern

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -36,10 +36,10 @@ if [ -f "plugin.rb" ]; then
 fi
 
 # Fix i18n helper invocations
-grep -rl '{{I18n' **/*.hbs | xargs sed -i '' 's/{{I18n/{{i18n/g'
+find . -name "*.hbs" | xargs sed -i '' 's/{{I18n/{{i18n/g'
 
 # Update all uses of `@class` argument
-grep -rl '@class=' **/*.{hbs,gjs} | xargs sed -i '' 's/@class=/class=/g'
+find . -name "*.hbs" -o -name "*.gjs" | xargs sed -i '' 's/@class=/class=/g'
 
 # Use the current linting setup
 if grep -q 'eslint-config-discourse' package.json; then

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -39,7 +39,7 @@ fi
 find . -name "*.hbs" | xargs sed -i '' 's/{{I18n/{{i18n/g'
 
 # Update all uses of `@class` argument
-if [ -n "$(find . -name '*.hbs' -o -name '*.gjs' | xargs grep '@class')" ]; then
+if [ -n "$(find . -name '*.hbs' -o -name '*.gjs' | xargs grep '@class=')" ]; then
   find . -name "*.hbs" -o -name "*.gjs" | xargs sed -i '' 's/@class=/class=/g'
   echo "[update-js-linting] Updated some '@class' args. Please review the changes."
   exit 1

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -38,6 +38,9 @@ fi
 # Fix i18n helper invocations
 grep -rl '{{I18n' **/*.hbs | xargs sed -i '' 's/{{I18n/{{i18n/g'
 
+# Update all uses of `@class` argument
+grep -rl '@class=' **/*.{hbs,gjs} | xargs sed -i '' 's/@class=/class=/g'
+
 # Use the current linting setup
 if grep -q 'eslint-config-discourse' package.json; then
   yarn remove eslint-config-discourse

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -39,7 +39,7 @@ fi
 find . -name "*.hbs" | xargs sed -i '' 's/{{I18n/{{i18n/g'
 
 # Update all uses of `@class` argument
-if find . -name "*.hbs" -o -name "*.gjs" | xargs grep -q "@class"; then
+if [ -n "$(find . -name '*.hbs' -o -name '*.gjs' | xargs grep '@class')" ]; then
   find . -name "*.hbs" -o -name "*.gjs" | xargs sed -i '' 's/@class=/class=/g'
   echo "[update-js-linting] Updated some '@class' args. Please review the changes."
   exit 1

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -71,6 +71,12 @@ if [ -n "$(find . -type f -not -path './node_modules*' -a -name '*.js' -o -name 
   exit 1
 fi
 
+# Find querySelector("html")
+if [ -n "$(find . -type f -not -path './node_modules*' -a -name '*.js' -o -name '*.gjs' | xargs grep 'querySelector("html")')" ]; then
+  echo "[update-js-linting] Found uses of querySelector(\"html\"). Please review the code and replace it with \`.documentElement\`."
+  exit 1
+fi
+
 if [ -f "plugin.rb" ]; then
   yarn eslint --fix --no-error-on-unmatched-pattern {test,assets,admin/assets}/javascripts || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)
 else # Theme

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -46,8 +46,8 @@ if [ -n "$(find . -type f -name '*.hbs' -o -name '*.gjs' | xargs grep '@class=')
 fi
 
 # Find this.transitionToRoute (in lieu of the eslint-ember rule)
-if [ -n "$(find . -type f -name '*.js' -o -name '*.gjs' | xargs grep 'this.transitionTo')" ]; then
-  echo "[update-js-linting] Found uses of deprecated this.transitionToRoute/this.transitionTo. Please review the code."
+if [ -n "$(find . -type f -name '*.js' -o -name '*.gjs' | xargs grep -E 'this\.(transitionTo|replaceWith|replaceRoute)')" ]; then
+  echo "[update-js-linting] Found uses of deprecated transitionToRoute/transitionTo/replaceWith/replaceRoute. Please review the code."
   exit 1
 fi
 

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -69,7 +69,7 @@ echo '{
   "name": "'$repo_name'",
   "private": true,
   "devDependencies": {
-    "@discourse/lint-configs": "^1.3.4",
+    "@discourse/lint-configs": "^1.3.5",
     "ember-template-lint": "^5.13.0",
     "eslint": "^8.56.0",
     "prettier": "^2.8.8"

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -35,9 +35,9 @@ yarn remove eslint-config-discourse
 yarn add --dev @discourse/lint-configs eslint prettier@^2.8.8 ember-template-lint
 
 if [ -f "plugin.rb" ]; then
-  yarn prettier --write '{assets,test}/**/*.{scss,js,hbs}' --no-error-on-unmatched-pattern
+  yarn prettier --write '{assets,test}/**/*.{scss,js,gjs,hbs}' --no-error-on-unmatched-pattern
 else # Theme
-  yarn prettier --write '{javascripts,desktop,mobile,common,scss,test}/**/*.{scss,js,hbs}' --no-error-on-unmatched-pattern
+  yarn prettier --write '{javascripts,desktop,mobile,common,scss,test}/**/*.{scss,js,gjs,hbs}' --no-error-on-unmatched-pattern
 fi
 
 if [ -f "plugin.rb" ]; then

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -10,18 +10,20 @@ find . -depth -name "*.js.es6" -exec sh -c 'mv "$1" "${1%.es6}"' _ {} \;
 
 # Remove the old config files
 rm -f .eslintrc
+rm -f .eslintrc.js
 rm -f .prettierrc
+rm -f .prettierrc.js
 rm -f .template-lintrc.js
 
 # Copy these files from skeleton if they do not already exist
 if [ -f "plugin.rb" ]; then
   cp -vn ../discourse-plugin-skeleton/.eslintrc.cjs . || true
   cp -vn ../discourse-plugin-skeleton/.prettierrc.cjs . || true
-  cp -vn ../discourse-plugin-skeleton/.template-lintrc.js . || true
+  cp -vn ../discourse-plugin-skeleton/.template-lintrc.cjs . || true
 else # Theme
   cp -vn ../discourse-theme-skeleton/.eslintrc.cjs . || true
   cp -vn ../discourse-theme-skeleton/.prettierrc.cjs . || true
-  cp -vn ../discourse-theme-skeleton/.template-lintrc.js . || true
+  cp -vn ../discourse-theme-skeleton/.template-lintrc.cjs . || true
 fi
 
 # Remove the old transpile_js option
@@ -33,13 +35,7 @@ fi
 
 # Use the current linting setup
 yarn remove eslint-config-discourse || true
-yarn add --dev @discourse/lint-configs eslint@^8.51.0 prettier@^2.8.8 ember-template-lint
-
-if [ -f "plugin.rb" ]; then
-  yarn prettier --write '{assets,test}/**/*.{scss,js,gjs,hbs}' --no-error-on-unmatched-pattern
-else # Theme
-  yarn prettier --write '{javascripts,desktop,mobile,common,scss,test}/**/*.{scss,js,gjs,hbs}' --no-error-on-unmatched-pattern
-fi
+yarn add --dev @discourse/lint-configs eslint@^8.54.0 prettier@^2.8.8 ember-template-lint@^5.13.0
 
 if [ -f "plugin.rb" ]; then
   yarn eslint --fix --no-error-on-unmatched-pattern {test,assets,admin/assets}/javascripts || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)
@@ -51,6 +47,12 @@ if [ -f "plugin.rb" ]; then
   yarn ember-template-lint --fix --no-error-on-unmatched-pattern 'assets/javascripts/**/*.{gjs,hbs}' 'admin/assets/javascripts/**/*.{gjs,hbs}' || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
 else # Theme
   yarn ember-template-lint --fix --no-error-on-unmatched-pattern 'javascripts/**/*.{gjs,hbs}' || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
+fi
+
+if [ -f "plugin.rb" ]; then
+  yarn prettier --write '{assets,test}/**/*.{scss,js,gjs,hbs}' --no-error-on-unmatched-pattern
+else # Theme
+  yarn prettier --write '{javascripts,desktop,mobile,common,scss,test}/**/*.{scss,js,gjs,hbs}' --no-error-on-unmatched-pattern
 fi
 
 cd ..

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -45,7 +45,7 @@ grep -rl '@class=' **/*.{hbs,gjs} | xargs sed -i '' 's/@class=/class=/g'
 if grep -q 'eslint-config-discourse' package.json; then
   yarn remove eslint-config-discourse
 fi
-yarn add --dev @discourse/lint-configs@^1.3.1 eslint@^8.55.0 prettier@^2.8.8 ember-template-lint@^5.13.0
+yarn add --dev @discourse/lint-configs@^1.3.4 eslint@^8.56.0 prettier@^2.8.8 ember-template-lint@^5.13.0
 
 if [ -f "plugin.rb" ]; then
   yarn eslint --fix --no-error-on-unmatched-pattern {test,assets,admin/assets}/javascripts || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -64,9 +64,9 @@ if [ -n "$(find . -type f -not -path './node_modules*' -a -name '*.hbs' -o -name
 fi
 
 # Use the current linting setup
-repo_name=$(git config --get remote.origin.url | grep -o '/\(.*\)' | cut -d'/' -f2)
+REPO_NAME=$(basename -s '.git' $(git -C repo remote get-url origin))
 echo '{
-  "name": "'$repo_name'",
+  "name": "'$REPO_NAME'",
   "private": true,
   "devDependencies": {
     "@discourse/lint-configs": "^1.3.5",

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -47,8 +47,7 @@ else # Theme
 fi
 
 if [ -f "plugin.rb" ]; then
-  yarn ember-template-lint --fix --no-error-on-unmatched-pattern assets/javascripts || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
-  yarn ember-template-lint --fix --no-error-on-unmatched-pattern admin/assets/javascripts || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
+  yarn ember-template-lint --fix --no-error-on-unmatched-pattern 'assets/javascripts' 'admin/assets/javascripts' || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
 else # Theme
   yarn ember-template-lint --fix --no-error-on-unmatched-pattern javascripts || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
 fi

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -37,7 +37,7 @@ fi
 
 # Use the current linting setup
 yarn remove eslint-config-discourse || true
-yarn add --dev @discourse/lint-configs eslint@^8.55.0 prettier@^2.8.8 ember-template-lint@^5.13.0
+yarn add --dev @discourse/lint-configs@^1.3.1 eslint@^8.55.0 prettier@^2.8.8 ember-template-lint@^5.13.0
 
 if [ -f "plugin.rb" ]; then
   yarn eslint --fix --no-error-on-unmatched-pattern {test,assets,admin/assets}/javascripts || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -36,29 +36,29 @@ if [ -f "plugin.rb" ]; then
 fi
 
 # Fix i18n helper invocations
-find . -type f -name "*.hbs" | xargs sed -i '' 's/{{I18n/{{i18n/g'
+find . -type f -not -path './node_modules*' -a -name "*.hbs" | xargs sed -i '' 's/{{I18n/{{i18n/g'
 
 # Update all uses of `@class` argument
-if [ -n "$(find . -type f -name '*.hbs' -o -name '*.gjs' | xargs grep '@class=')" ]; then
+if [ -n "$(find . -type f -not -path './node_modules*' -a -name '*.hbs' -o -name '*.gjs' | xargs grep '@class=')" ]; then
   find . -type f -name "*.hbs" -o -name "*.gjs" | xargs sed -i '' 's/@class=/class=/g'
   echo "[update-js-linting] Updated some '@class' args. Please review the changes."
   exit 1
 fi
 
 # Find this.transitionToRoute (in lieu of the eslint-ember rule)
-if [ -n "$(find . -type f -name '*.js' -o -name '*.gjs' | xargs grep -E 'this\.(transitionTo|replaceWith|replaceRoute)')" ]; then
+if [ -n "$(find . -type f -not -path './node_modules*' -a -name '*.js' -o -name '*.gjs' | xargs grep -E 'this\.(transitionTo|replaceWith|replaceRoute)')" ]; then
   echo "[update-js-linting] Found uses of deprecated transitionToRoute/transitionTo/replaceWith/replaceRoute. Please review the code."
   exit 1
 fi
 
 # Find deprecated lookups, like "site:main"
-if [ -n "$(find . -type f -name '*.js' | xargs grep ':main\"')" ]; then
+if [ -n "$(find . -type f -not -path './node_modules*' -a -name '*.js' | xargs grep ':main\"')" ]; then
   echo "[update-js-linting] Found uses of deprecated '*:main' lookups. Please review the code."
   exit 1
 fi
 
 # Find uses of deprecated DSection
-if [ -n "$(find . -type f -name '*.hbs' -o -name '*.gjs' | xargs grep -E '<DSection|{{#d-section')" ]; then
+if [ -n "$(find . -type f -not -path './node_modules*' -a -name '*.hbs' -o -name '*.gjs' | xargs grep -E '<DSection|{{#d-section')" ]; then
   echo "[update-js-linting] Found uses of deprecated <DSection />/{{#d-section}}. Please review the code."
   exit 1
 fi

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -39,7 +39,11 @@ fi
 find . -name "*.hbs" | xargs sed -i '' 's/{{I18n/{{i18n/g'
 
 # Update all uses of `@class` argument
-find . -name "*.hbs" -o -name "*.gjs" | xargs sed -i '' 's/@class=/class=/g'
+if find . -name "*.hbs" -o -name "*.gjs" | xargs grep -q "@class"; then
+  find . -name "*.hbs" -o -name "*.gjs" | xargs sed -i '' 's/@class=/class=/g'
+  echo "[update-js-linting] Updated some '@class' args. Please review the changes."
+  exit 1
+fi
 
 # Use the current linting setup
 repo_name=$(git config --get remote.origin.url | grep -o '/\(.*\)' | cut -d'/' -f2)

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -23,6 +23,13 @@ else # Theme
   cp -vn ../discourse-theme-skeleton/.template-lintrc.js . || true
 fi
 
+# Remove the old transpile_js option
+if [ -f "repo/plugin.rb" ]; then
+  if grep -q 'transpile_js: true' plugin.rb; then
+    ruby -e 'File.write("plugin.rb", File.read("plugin.rb").gsub(/^# transpile_js: true\n/, ""))'
+  end
+fi
+
 # Use the current linting setup
 yarn remove eslint-config-discourse
 yarn add --dev @discourse/lint-configs eslint prettier@^2.8.8 ember-template-lint

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -51,7 +51,7 @@ else # Theme
 fi
 
 if [ -f "plugin.rb" ]; then
-  yarn prettier --write '{assets,test}/**/*.{scss,js,gjs,hbs}' --no-error-on-unmatched-pattern
+  yarn prettier --write '{assets,admin/assets,test}/**/*.{scss,js,gjs,hbs}' --no-error-on-unmatched-pattern
 else # Theme
   yarn prettier --write '{javascripts,desktop,mobile,common,scss,test}/**/*.{scss,js,gjs,hbs}' --no-error-on-unmatched-pattern
 fi

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -15,6 +15,8 @@ rm -f .prettierrc
 rm -f .prettierrc.js
 rm -f .template-lintrc.js
 
+rm -f package-lock.json
+
 # Copy these files from skeleton if they do not already exist
 if [ -f "plugin.rb" ]; then
   cp -vn ../discourse-plugin-skeleton/.eslintrc.cjs . || true

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -47,9 +47,9 @@ else # Theme
 fi
 
 if [ -f "plugin.rb" ]; then
-  yarn ember-template-lint --fix --no-error-on-unmatched-pattern 'assets/javascripts' 'admin/assets/javascripts' || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
+  yarn ember-template-lint --fix --no-error-on-unmatched-pattern 'assets/javascripts/**/*.{gjs,hbs}' 'admin/assets/javascripts/**/*.{gjs,hbs}' || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
 else # Theme
-  yarn ember-template-lint --fix --no-error-on-unmatched-pattern javascripts || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
+  yarn ember-template-lint --fix --no-error-on-unmatched-pattern 'javascripts/**/*.{gjs,hbs}' || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
 fi
 
 cd ..

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -47,6 +47,13 @@ if [ -n "$(find . -type f -not -path './node_modules*' -a -name '*.hbs' -o -name
   exit 1
 fi
 
+# Update all uses of `inject as service`
+if [ -n "$(find . -type f -not -path './node_modules*' -a -name '*.hbs' -o -name '*.gjs' | xargs grep 'inject as service')" ]; then
+  find . -type f -name "*.hbs" -o -name "*.gjs" | xargs sed -i '' 's/inject as service/service/g'
+  echo "[update-js-linting] Updated 'inject as service' imports. Please review the changes."
+  exit 1
+fi
+
 # Find this.transitionToRoute (in lieu of the eslint-ember rule)
 if [ -n "$(find . -type f -not -path './node_modules*' -a -name '*.js' -o -name '*.gjs' | xargs grep -E 'this\.(transitionTo|replaceWith|replaceRoute)')" ]; then
   echo "[update-js-linting] Found uses of deprecated transitionToRoute/transitionTo/replaceWith/replaceRoute. Please review the code."

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -46,8 +46,8 @@ if [ -n "$(find . -type f -name '*.hbs' -o -name '*.gjs' | xargs grep '@class=')
 fi
 
 # Find this.transitionToRoute (in lieu of the eslint-ember rule)
-if [ -n "$(find . -type f -name '*.js' -o -name '*.gjs' | xargs grep 'this.transitionToRoute')" ]; then
-  echo "[update-js-linting] Found uses of deprecated transitionToRoute. Please review the code."
+if [ -n "$(find . -type f -name '*.js' -o -name '*.gjs' | xargs grep 'this.transitionTo')" ]; then
+  echo "[update-js-linting] Found uses of deprecated this.transitionToRoute/this.transitionTo. Please review the code."
   exit 1
 fi
 

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -36,29 +36,29 @@ if [ -f "plugin.rb" ]; then
 fi
 
 # Fix i18n helper invocations
-find . -name "*.hbs" | xargs sed -i '' 's/{{I18n/{{i18n/g'
+find . -type f -name "*.hbs" | xargs sed -i '' 's/{{I18n/{{i18n/g'
 
 # Update all uses of `@class` argument
-if [ -n "$(find . -name '*.hbs' -o -name '*.gjs' | xargs grep '@class=')" ]; then
-  find . -name "*.hbs" -o -name "*.gjs" | xargs sed -i '' 's/@class=/class=/g'
+if [ -n "$(find . -type f -name '*.hbs' -o -name '*.gjs' | xargs grep '@class=')" ]; then
+  find . -type f -name "*.hbs" -o -name "*.gjs" | xargs sed -i '' 's/@class=/class=/g'
   echo "[update-js-linting] Updated some '@class' args. Please review the changes."
   exit 1
 fi
 
 # Find this.transitionToRoute (in lieu of the eslint-ember rule)
-if [ -n "$(find . -name '*.js' -o -name '*.gjs' | xargs grep 'this.transitionToRoute')" ]; then
+if [ -n "$(find . -type f -name '*.js' -o -name '*.gjs' | xargs grep 'this.transitionToRoute')" ]; then
   echo "[update-js-linting] Found uses of deprecated transitionToRoute. Please review the code."
   exit 1
 fi
 
 # Find deprecated lookups, like "site:main"
-if [ -n "$(find . -name '*.js' | xargs grep ':main\"')" ]; then
+if [ -n "$(find . -type f -name '*.js' | xargs grep ':main\"')" ]; then
   echo "[update-js-linting] Found uses of deprecated '*:main' lookups. Please review the code."
   exit 1
 fi
 
 # Find uses of deprecated DSection
-if [ -n "$(find . -name '*.hbs' -o -name '*.gjs' | xargs grep -E '<DSection|{{#d-section')" ]; then
+if [ -n "$(find . -type f -name '*.hbs' -o -name '*.gjs' | xargs grep -E '<DSection|{{#d-section')" ]; then
   echo "[update-js-linting] Found uses of deprecated <DSection />/{{#d-section}}. Please review the code."
   exit 1
 fi

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -30,6 +30,11 @@ fi
 
 yarn install
 
+# Move tests out of test/javascripts
+if [ -f "about.json" ]; then
+  mv test/javascripts/* test/
+fi
+
 # Remove the old transpile_js option
 if [ -f "plugin.rb" ]; then
   if grep -q 'transpile_js: true' plugin.rb; then

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -36,7 +36,9 @@ if [ -f "plugin.rb" ]; then
 fi
 
 # Use the current linting setup
-yarn remove eslint-config-discourse --silent || true
+if grep -q 'eslint-config-discourse' package.json; then
+  yarn remove eslint-config-discourse
+fi
 yarn add --dev @discourse/lint-configs@^1.3.1 eslint@^8.55.0 prettier@^2.8.8 ember-template-lint@^5.13.0
 
 if [ -f "plugin.rb" ]; then

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -37,7 +37,7 @@ fi
 
 # Use the current linting setup
 yarn remove eslint-config-discourse || true
-yarn add --dev @discourse/lint-configs eslint@^8.54.0 prettier@^2.8.8 ember-template-lint@^5.13.0
+yarn add --dev @discourse/lint-configs eslint@^8.55.0 prettier@^2.8.8 ember-template-lint@^5.13.0
 
 if [ -f "plugin.rb" ]; then
   yarn eslint --fix --no-error-on-unmatched-pattern {test,assets,admin/assets}/javascripts || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -13,7 +13,7 @@ rm .eslintrc
 rm .prettierrc
 
 # Copy these files from skeleton if they do not already exist
-if [ -f "repo/plugin.rb" ]; then
+if [ -f "plugin.rb" ]; then
   cp -vn ../discourse-plugin-skeleton/.eslintrc.cjs . || true
   cp -vn ../discourse-plugin-skeleton/.prettierrc.cjs . || true
   cp -vn ../discourse-plugin-skeleton/.template-lintrc.js . || true
@@ -24,7 +24,7 @@ else # Theme
 fi
 
 # Remove the old transpile_js option
-if [ -f "repo/plugin.rb" ]; then
+if [ -f "plugin.rb" ]; then
   if grep -q 'transpile_js: true' plugin.rb; then
     ruby -e 'File.write("plugin.rb", File.read("plugin.rb").gsub(/^# transpile_js: true\n/, ""))'
   fi

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -32,7 +32,7 @@ if [ -f "plugin.rb" ]; then
 fi
 
 # Use the current linting setup
-yarn remove eslint-config-discourse
+yarn remove eslint-config-discourse || true
 yarn add --dev @discourse/lint-configs eslint prettier@^2.8.8 ember-template-lint
 
 if [ -f "plugin.rb" ]; then

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -65,6 +65,12 @@ if [ -n "$(find . -type f -not -path './node_modules*' -a -name '*.hbs' -o -name
   exit 1
 fi
 
+# Find querySelector("body")
+if [ -n "$(find . -type f -not -path './node_modules*' -a -name '*.js' -o -name '*.gjs' | xargs grep 'querySelector("body")')" ]; then
+  echo "[update-js-linting] Found uses of querySelector(\"body\"). Please review the code and replace it with \`.body\`."
+  exit 1
+fi
+
 if [ -f "plugin.rb" ]; then
   yarn eslint --fix --no-error-on-unmatched-pattern {test,assets,admin/assets}/javascripts || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)
 else # Theme

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -45,6 +45,18 @@ if [ -n "$(find . -name '*.hbs' -o -name '*.gjs' | xargs grep '@class=')" ]; the
   exit 1
 fi
 
+# Find this.transitionToRoute (in lieu of the eslint-ember rule)
+if [ -n "$(find . -name '*.js' -o -name '*.gjs' | xargs grep 'this.transitionToRoute')" ]; then
+  echo "[update-js-linting] Found uses of deprecated transitionToRoute. Please review the code."
+  exit 1
+fi
+
+# Find deprecated lookups, like "site:main"
+if [ -n "$(find . -name '*.js' | xargs grep ':main\"')" ]; then
+  echo "[update-js-linting] Found uses of deprecated '*:main' lookups. Please review the code."
+  exit 1
+fi
+
 # Find uses of deprecated DSection
 if [ -n "$(find . -name '*.hbs' -o -name '*.gjs' | xargs grep -E '<DSection|{{#d-section')" ]; then
   echo "[update-js-linting] Found uses of deprecated <DSection />/{{#d-section}}. Please review the code."

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -41,9 +41,9 @@ else # Theme
 fi
 
 if [ -f "plugin.rb" ]; then
-  yarn eslint --ext .js --no-error-on-unmatched-pattern {test,assets,admin/assets}/javascripts || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)
+  yarn eslint --no-error-on-unmatched-pattern {test,assets,admin/assets}/javascripts || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)
 else # Theme
-  yarn eslint --ext .js --no-error-on-unmatched-pattern {test,javascripts} || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)
+  yarn eslint --no-error-on-unmatched-pattern {test,javascripts} || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)
 fi
 
 if [ -f "plugin.rb" ]; then

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -44,7 +44,8 @@ else # Theme
 fi
 
 if [ -f "plugin.rb" ]; then
-  yarn ember-template-lint --fix --no-error-on-unmatched-pattern 'assets/javascripts/**/*.{gjs,hbs}' 'admin/assets/javascripts/**/*.{gjs,hbs}' || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
+  yarn ember-template-lint --fix --no-error-on-unmatched-pattern 'assets/javascripts/**/*.{gjs,hbs}' || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
+  yarn ember-template-lint --fix --no-error-on-unmatched-pattern 'admin/assets/javascripts/**/*.{gjs,hbs}' || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
 else # Theme
   yarn ember-template-lint --fix --no-error-on-unmatched-pattern 'javascripts/**/*.{gjs,hbs}' || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
 fi

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -42,10 +42,18 @@ find . -name "*.hbs" | xargs sed -i '' 's/{{I18n/{{i18n/g'
 find . -name "*.hbs" -o -name "*.gjs" | xargs sed -i '' 's/@class=/class=/g'
 
 # Use the current linting setup
-if grep -q 'eslint-config-discourse' package.json; then
-  yarn remove eslint-config-discourse
-fi
-yarn add --dev @discourse/lint-configs@^1.3.4 eslint@^8.56.0 prettier@^2.8.8 ember-template-lint@^5.13.0
+repo_name=$(git config --get remote.origin.url | grep -o '/\(.*\)' | cut -d'/' -f2)
+echo '{
+  "name": "'$repo_name'",
+  "private": true,
+  "devDependencies": {
+    "@discourse/lint-configs": "^1.3.4",
+    "ember-template-lint": "^5.13.0",
+    "eslint": "^8.56.0",
+    "prettier": "^2.8.8"
+  }
+}' > package.json
+yarn install
 
 if [ -f "plugin.rb" ]; then
   yarn eslint --fix --no-error-on-unmatched-pattern {test,assets,admin/assets}/javascripts || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -27,7 +27,7 @@ fi
 if [ -f "repo/plugin.rb" ]; then
   if grep -q 'transpile_js: true' plugin.rb; then
     ruby -e 'File.write("plugin.rb", File.read("plugin.rb").gsub(/^# transpile_js: true\n/, ""))'
-  end
+  fi
 fi
 
 # Use the current linting setup

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -9,9 +9,9 @@ cd repo
 find . -depth -name "*.js.es6" -exec sh -c 'mv "$1" "${1%.es6}"' _ {} \;
 
 # Remove the old config files
-rm .eslintrc
-rm .prettierrc
-rm .template-lintrc.js
+rm -f .eslintrc
+rm -f .prettierrc
+rm -f .template-lintrc.js
 
 # Copy these files from skeleton if they do not already exist
 if [ -f "plugin.rb" ]; then

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -45,6 +45,12 @@ if [ -n "$(find . -name '*.hbs' -o -name '*.gjs' | xargs grep '@class=')" ]; the
   exit 1
 fi
 
+# Find uses of deprecated DSection
+if [ -n "$(find . -name '*.hbs' -o -name '*.gjs' | xargs grep -E '<DSection|{{#d-section')" ]; then
+  echo "[update-js-linting] Found uses of deprecated <DSection />/{{#d-section}}. Please review the code."
+  exit 1
+fi
+
 # Use the current linting setup
 repo_name=$(git config --get remote.origin.url | grep -o '/\(.*\)' | cut -d'/' -f2)
 echo '{

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -35,6 +35,9 @@ if [ -f "plugin.rb" ]; then
   fi
 fi
 
+# Fix i18n helper invocations
+grep -rl '{{I18n' **/*.hbs | xargs sed -i '' 's/{{I18n/{{i18n/g'
+
 # Use the current linting setup
 if grep -q 'eslint-config-discourse' package.json; then
   yarn remove eslint-config-discourse

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -28,6 +28,8 @@ else # Theme
   cp -vn ../discourse-theme-skeleton/.template-lintrc.cjs . || true
 fi
 
+yarn install
+
 # Remove the old transpile_js option
 if [ -f "plugin.rb" ]; then
   if grep -q 'transpile_js: true' plugin.rb; then
@@ -62,20 +64,6 @@ if [ -n "$(find . -type f -not -path './node_modules*' -a -name '*.hbs' -o -name
   echo "[update-js-linting] Found uses of deprecated <DSection />/{{#d-section}}. Please review the code."
   exit 1
 fi
-
-# Use the current linting setup
-REPO_NAME=$(basename -s '.git' $(git -C repo remote get-url origin))
-echo '{
-  "name": "'$REPO_NAME'",
-  "private": true,
-  "devDependencies": {
-    "@discourse/lint-configs": "^1.3.5",
-    "ember-template-lint": "^5.13.0",
-    "eslint": "^8.56.0",
-    "prettier": "^2.8.8"
-  }
-}' > package.json
-yarn install
 
 if [ -f "plugin.rb" ]; then
   yarn eslint --fix --no-error-on-unmatched-pattern {test,assets,admin/assets}/javascripts || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -50,8 +50,7 @@ fi
 # Update all uses of `inject as service`
 if [ -n "$(find . -type f -not -path './node_modules*' -a -name '*.hbs' -o -name '*.gjs' | xargs grep 'inject as service')" ]; then
   find . -type f -name "*.hbs" -o -name "*.gjs" | xargs sed -i '' 's/inject as service/service/g'
-  echo "[update-js-linting] Updated 'inject as service' imports. Please review the changes."
-  exit 1
+  echo "[update-js-linting] Updated 'inject as service' imports."
 fi
 
 # Find this.transitionToRoute (in lieu of the eslint-ember rule)

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -41,16 +41,16 @@ else # Theme
 fi
 
 if [ -f "plugin.rb" ]; then
-  yarn eslint --no-error-on-unmatched-pattern {test,assets,admin/assets}/javascripts || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)
+  yarn eslint --fix --no-error-on-unmatched-pattern {test,assets,admin/assets}/javascripts || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)
 else # Theme
-  yarn eslint --no-error-on-unmatched-pattern {test,javascripts} || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)
+  yarn eslint --fix --no-error-on-unmatched-pattern {test,javascripts} || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)
 fi
 
 if [ -f "plugin.rb" ]; then
-  yarn ember-template-lint --no-error-on-unmatched-pattern assets/javascripts || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
-  yarn ember-template-lint --no-error-on-unmatched-pattern admin/assets/javascripts || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
+  yarn ember-template-lint --fix --no-error-on-unmatched-pattern assets/javascripts || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
+  yarn ember-template-lint --fix --no-error-on-unmatched-pattern admin/assets/javascripts || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
 else # Theme
-  yarn ember-template-lint --no-error-on-unmatched-pattern javascripts || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
+  yarn ember-template-lint --fix --no-error-on-unmatched-pattern javascripts || (echo "[update-js-linting] ember-template-lint failed, fix violations and re-run script" && exit 1)
 fi
 
 cd ..

--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -11,6 +11,7 @@ find . -depth -name "*.js.es6" -exec sh -c 'mv "$1" "${1%.es6}"' _ {} \;
 # Remove the old config files
 rm .eslintrc
 rm .prettierrc
+rm .template-lintrc.js
 
 # Copy these files from skeleton if they do not already exist
 if [ -f "plugin.rb" ]; then

--- a/scripts/update-linting.sh
+++ b/scripts/update-linting.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euxo pipefail
+
+../scripts/update-rb-linting.sh
+../scripts/update-js-linting.sh

--- a/scripts/update-linting.sh
+++ b/scripts/update-linting.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
 
-../scripts/update-rb-linting.sh || true
+../scripts/update-rb-linting.sh
 ../scripts/update-js-linting.sh

--- a/scripts/update-linting.sh
+++ b/scripts/update-linting.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -euxo pipefail
 
-../scripts/update-rb-linting.sh
+../scripts/update-rb-linting.sh || true
 ../scripts/update-js-linting.sh

--- a/scripts/update-rb-linting.sh
+++ b/scripts/update-rb-linting.sh
@@ -47,7 +47,7 @@ bundle lock --remove-platform arm64-darwin-21 &> /dev/null || true
 bundle lock --remove-platform arm64-darwin-22 &> /dev/null || true
 
 # Remove unnecessary requires
-find spec/ -name "*.rb" | xargs sed -i '' 's/require "rails_helper"//'
+test -d /spec && find spec/ -name "*.rb" | xargs sed -i '' 's/require "rails_helper"//'
 
 # Format and lint
 bundle exec stree write Gemfile $(git ls-files "*.rb") $(git ls-files "*.rake")

--- a/scripts/update-rb-linting.sh
+++ b/scripts/update-rb-linting.sh
@@ -32,9 +32,7 @@ if grep -q ',disable_ternary' .streerc; then
   sed -i "" "s:trailing_comma.*:trailing_comma,plugin/disable_auto_ternary:" .streerc
 fi
 
-bundle lock --add-platform x86_64-linux
-bundle lock --add-platform arm64-darwin-20
-bundle lock --add-platform arm64-darwin-22
+bundle update --bundler
 bundle update
 
 sed -i "" "s/default.yml/stree-compat.yml/" .rubocop.yml

--- a/scripts/update-rb-linting.sh
+++ b/scripts/update-rb-linting.sh
@@ -27,6 +27,8 @@ fi
 # Remove the old stree plugin
 if grep -q 'syntax_tree-disable_ternary' Gemfile; then
   ruby -e 'File.write("Gemfile", File.read("Gemfile").gsub(/^\s*gem .syntax_tree-disable_ternary.\n/, ""))'
+fi
+if grep -q ',disable_ternary' .streerc; then
   sed -i "" "s:trailing_comma.*:trailing_comma,plugin/disable_auto_ternary:" .streerc
 fi
 

--- a/scripts/update-rb-linting.sh
+++ b/scripts/update-rb-linting.sh
@@ -31,6 +31,7 @@ if grep -q 'syntax_tree-disable_ternary' Gemfile; then
 fi
 
 bundle lock --add-platform x86_64-linux
+bundle lock --add-platform arm64-darwin-20
 bundle update
 
 sed -i "" "s/default.yml/stree-compat.yml/" .rubocop.yml

--- a/scripts/update-rb-linting.sh
+++ b/scripts/update-rb-linting.sh
@@ -17,7 +17,7 @@ cp -vn ../discourse-plugin-skeleton/Gemfile . || true
 
 # Add stree
 if ! grep -q 'syntax_tree' Gemfile; then
-  sed -i "" "s/gem 'rubocop-discourse'/gem 'rubocop-discourse'; gem 'syntax_tree'/" Gemfile
+  sed -i "" "s/gem .rubocop-discourse./gem 'rubocop-discourse'; gem 'syntax_tree'/" Gemfile
   if ! grep -q 'syntax_tree' Gemfile; then
     echo "Unable to automatically install syntax tree. Please fix the Gemfile and restart the script;"
     exit 1

--- a/scripts/update-rb-linting.sh
+++ b/scripts/update-rb-linting.sh
@@ -32,13 +32,14 @@ if grep -q ',disable_ternary' .streerc; then
   sed -i "" "s:trailing_comma.*:trailing_comma,plugin/disable_auto_ternary:" .streerc
 fi
 
-bundle lock --remove-platform x86_64-linux
-bundle lock --remove-platform x86_64-darwin-18
-bundle lock --remove-platform x86_64-darwin-19
-bundle lock --remove-platform x86_64-darwin-20
-bundle lock --remove-platform arm64-darwin-20
-bundle lock --remove-platform arm64-darwin-21
-bundle lock --remove-platform arm64-darwin-22
+bundle lock --add-platform ruby
+bundle lock --remove-platform x86_64-linux &> /dev/null || true
+bundle lock --remove-platform x86_64-darwin-18 &> /dev/null || true
+bundle lock --remove-platform x86_64-darwin-19 &> /dev/null || true
+bundle lock --remove-platform x86_64-darwin-20 &> /dev/null || true
+bundle lock --remove-platform arm64-darwin-20 &> /dev/null || true
+bundle lock --remove-platform arm64-darwin-21 &> /dev/null || true
+bundle lock --remove-platform arm64-darwin-22 &> /dev/null || true
 
 bundle update --bundler
 bundle update

--- a/scripts/update-rb-linting.sh
+++ b/scripts/update-rb-linting.sh
@@ -32,6 +32,8 @@ if grep -q ',disable_ternary' .streerc; then
   sed -i "" "s:trailing_comma.*:trailing_comma,plugin/disable_auto_ternary:" .streerc
 fi
 
+sed -i "" "s/default.yml/stree-compat.yml/" .rubocop.yml
+
 bundle update
 bundle update --bundler
 
@@ -44,10 +46,11 @@ bundle lock --remove-platform arm64-darwin-20 &> /dev/null || true
 bundle lock --remove-platform arm64-darwin-21 &> /dev/null || true
 bundle lock --remove-platform arm64-darwin-22 &> /dev/null || true
 
-sed -i "" "s/default.yml/stree-compat.yml/" .rubocop.yml
+# Remove unnecessary requires
+find spec/ -name "*.rb" | xargs sed -i '' 's/require "rails_helper"//'
 
+# Format and lint
 bundle exec stree write Gemfile $(git ls-files "*.rb") $(git ls-files "*.rake")
-
 bundle exec rubocop -A . || (echo "[update-rb-linting] rubocop failed. Correct violations and rerun script." && exit 1)
 
 # Second stree run to format any rubocop auto-fixes

--- a/scripts/update-rb-linting.sh
+++ b/scripts/update-rb-linting.sh
@@ -32,6 +32,7 @@ if grep -q ',disable_ternary' .streerc; then
   sed -i "" "s:trailing_comma.*:trailing_comma,plugin/disable_auto_ternary:" .streerc
 fi
 
+bundle update
 bundle update --bundler
 
 bundle lock --add-platform ruby
@@ -42,8 +43,6 @@ bundle lock --remove-platform x86_64-darwin-20 &> /dev/null || true
 bundle lock --remove-platform arm64-darwin-20 &> /dev/null || true
 bundle lock --remove-platform arm64-darwin-21 &> /dev/null || true
 bundle lock --remove-platform arm64-darwin-22 &> /dev/null || true
-
-bundle update
 
 sed -i "" "s/default.yml/stree-compat.yml/" .rubocop.yml
 

--- a/scripts/update-rb-linting.sh
+++ b/scripts/update-rb-linting.sh
@@ -32,6 +32,7 @@ fi
 
 bundle lock --add-platform x86_64-linux
 bundle lock --add-platform arm64-darwin-20
+bundle lock --add-platform arm64-darwin-22
 bundle update
 
 sed -i "" "s/default.yml/stree-compat.yml/" .rubocop.yml

--- a/scripts/update-rb-linting.sh
+++ b/scripts/update-rb-linting.sh
@@ -32,6 +32,8 @@ if grep -q ',disable_ternary' .streerc; then
   sed -i "" "s:trailing_comma.*:trailing_comma,plugin/disable_auto_ternary:" .streerc
 fi
 
+bundle update --bundler
+
 bundle lock --add-platform ruby
 bundle lock --remove-platform x86_64-linux &> /dev/null || true
 bundle lock --remove-platform x86_64-darwin-18 &> /dev/null || true
@@ -41,7 +43,6 @@ bundle lock --remove-platform arm64-darwin-20 &> /dev/null || true
 bundle lock --remove-platform arm64-darwin-21 &> /dev/null || true
 bundle lock --remove-platform arm64-darwin-22 &> /dev/null || true
 
-bundle update --bundler
 bundle update
 
 sed -i "" "s/default.yml/stree-compat.yml/" .rubocop.yml

--- a/scripts/update-rb-linting.sh
+++ b/scripts/update-rb-linting.sh
@@ -7,7 +7,7 @@ cd repo
 
 if [ ! -f "plugin.rb" ]; then
   echo "Not a plugin, skipping ruby operations"
-  exit 1
+  exit 0
 fi
 
 # Copy these files from skeleton if they do not already exist

--- a/scripts/update-rb-linting.sh
+++ b/scripts/update-rb-linting.sh
@@ -32,6 +32,14 @@ if grep -q ',disable_ternary' .streerc; then
   sed -i "" "s:trailing_comma.*:trailing_comma,plugin/disable_auto_ternary:" .streerc
 fi
 
+bundle lock --remove-platform x86_64-linux
+bundle lock --remove-platform x86_64-darwin-18
+bundle lock --remove-platform x86_64-darwin-19
+bundle lock --remove-platform x86_64-darwin-20
+bundle lock --remove-platform arm64-darwin-20
+bundle lock --remove-platform arm64-darwin-21
+bundle lock --remove-platform arm64-darwin-22
+
 bundle update --bundler
 bundle update
 


### PR DESCRIPTION
1. Don't setup any rb files when running js linting script, and no js when running rb linting one
2. Don't try to lint .es6 files (they're renamed earlier to .js)
3. Update the syntax tree setup (remove the custom plugin)
4. Update the js linting setup (`@discourse/lint-configs`)
5. Show a more precise error when passing in a nonexistent script path
6. Add `--ask` option that pauses before creating a PR
7. Clean up package.json and Gemfile.lock files