### PR TITLE
DEV: improve fontawesome icon remapping script to recognise more patterns

### DIFF
--- a/scripts/map_font_awesome_6_icon_names.rb
+++ b/scripts/map_font_awesome_6_icon_names.rb
@@ -754,7 +754,7 @@ def process_file(file_path, replacement_patterns)
       puts "Found original icons: #{original_icons.join(', ')}"
       original_icons.each do |icon|
         new_icon, has_FA5_icon_name = remap_icon_name(icon)
-        puts "Mapped #{icon} to new icon: #{new_icon}"
+        puts "Mapped #{icon} to new icon: #{new_icon}" if icon != new_icon
         should_update_compat ||= has_FA5_icon_name
         match.sub!(icon, new_icon)
       end


### PR DESCRIPTION
We now recognise the additional patterns:

* `@icon=` in hbs, gjs files
* `replaceIcon` in gjs, js, html files 

Also modifies parsing to capture multiple matching groups of strings in-between single/double quotes - primarily to handle `replaceIcon` calls which take 2 parameters.