### PR TITLE
js-native-class: unfreeze mutated strings

### DIFF
--- a/scripts/js-native-class.rb
+++ b/scripts/js-native-class.rb
@@ -7,8 +7,8 @@ CONTROL_CHARS = /\e\[[^\x40-\x7E]*[\x40-\x7E]/
 
 def stream_and_capture(*cmd)
   status = nil
-  stdout_str = ""
-  stderr_str = ""
+  stdout_str = +""
+  stderr_str = +""
 
   Open3.popen3(*cmd) do |stdin, stdout, stderr, wait_thr|
     Thread.new do


### PR DESCRIPTION
frozen_string_literal was added when we enabled Ruby linting on this repo, but the script mutates these two strings