### PR TITLE
DEV: make in-place edits portable across GNU/BSD sed

### DIFF
--- a/scripts/update-js-linting.sh
+++ b/scripts/update-js-linting.sh
@@ -48,7 +48,7 @@ if [ -f "plugin.rb" ]; then
 fi
 
 # Fix i18n helper invocations
-find . -type f -not -path './node_modules*' -a -name "*.hbs" | xargs sed -i '' 's/{{I18n/{{i18n/g'
+find . -type f -not -path './node_modules*' -a -name "*.hbs" | xargs -r perl -pi -e 's/\{\{I18n/{{i18n/g'
 
 if [ -f "plugin.rb" ]; then
   pnpm eslint --fix --max-warnings 0 --no-error-on-unmatched-pattern {test,assets,admin/assets}/javascripts || (echo "[update-js-linting] eslint failed, fix violations and re-run script" && exit 1)

--- a/scripts/update-rb-linting.sh
+++ b/scripts/update-rb-linting.sh
@@ -16,7 +16,7 @@ fi
 
 # Add stree
 if ! grep -q 'syntax_tree' Gemfile; then
-  sed -i "" "s/gem .rubocop-discourse./gem 'rubocop-discourse'; gem 'syntax_tree'/" Gemfile
+  perl -pi -e "s/gem .rubocop-discourse./gem 'rubocop-discourse'; gem 'syntax_tree'/" Gemfile
   if ! grep -q 'syntax_tree' Gemfile; then
     echo "Unable to automatically install syntax tree. Please fix the Gemfile and restart the script;"
     exit 1
@@ -28,10 +28,10 @@ if grep -q 'syntax_tree-disable_ternary' Gemfile; then
   ruby -e 'File.write("Gemfile", File.read("Gemfile").gsub(/^\s*gem .syntax_tree-disable_ternary.\n/, ""))'
 fi
 if grep -q ',disable_ternary' .streerc; then
-  sed -i "" "s:trailing_comma.*:trailing_comma,plugin/disable_auto_ternary:" .streerc
+  perl -pi -e "s:trailing_comma.*:trailing_comma,plugin/disable_auto_ternary:" .streerc
 fi
 
-sed -i "" "s/default.yml/stree-compat.yml/" .rubocop.yml
+perl -pi -e "s/default.yml/stree-compat.yml/" .rubocop.yml
 
 if [ ! -f "Gemfile.lock" ]; then
   bundle install
@@ -49,10 +49,10 @@ bundle lock --remove-platform arm64-darwin-21 &> /dev/null || true
 bundle lock --remove-platform arm64-darwin-22 &> /dev/null || true
 
 # Remove unnecessary requires
-test -d spec && find spec/ -name "*.rb" | xargs sed -i '' 's/require "rails_helper"//'
+test -d spec && find spec/ -name "*.rb" | xargs -r perl -pi -e 's/require "rails_helper"//'
 
 # Remove unnecessary `js: true` flags in specs
-test -d spec && find spec/ -name "*.rb" | xargs sed -i '' 's/, js: true//'
+test -d spec && find spec/ -name "*.rb" | xargs -r perl -pi -e 's/, js: true//'
 
 # Format and lint
 bundle exec stree write Gemfile $(git ls-files "*.rb") $(git ls-files "*.rake")


### PR DESCRIPTION
`sed -i ''` is BSD-specific; on Linux (GNU sed) it fails with e.g.:

```
sed: can't read s/default.yml/stree-compat.yml/: No such file or directory
```

which aborts `update-rb-linting.sh` / `update-js-linting.sh` (and therefore `update-linting.sh`) for anyone running mass-pr on Linux.

This replaces the `sed -i ''` calls with `perl -pi -e`, which behaves identically on macOS and Linux (patterns unchanged, verified output matches).

Also adds `xargs -r` to the `find | xargs` pipelines so a repo with no matching files (e.g. a plugin with no `.hbs` files) skips the edit instead of erroring under `set -e`. `-r` is the GNU flag; BSD xargs accepts it as a no-op since not running on empty input is already its default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)